### PR TITLE
Fix crash when HTTP entrypoint raises exception.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+0.1.1 (2020-02-13)
+------------------
+
+* Fixed crash when HTTP entrypoint raised an exception.
+
 0.1 (2019-10-01)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="nameko-prometheus",
-    version="0.1",
+    version="0.1.1",
     license="Apache-2.0",
     description="Prometheus metrics collector and exporter for nameko microservice framework",
     long_description=long_description,

--- a/src/nameko_prometheus/__init__.py
+++ b/src/nameko_prometheus/__init__.py
@@ -1,3 +1,3 @@
 from nameko_prometheus.dependencies import PrometheusMetrics
 
-__version__ = "0.1"
+__version__ = "0.1.1"

--- a/src/nameko_prometheus/dependencies.py
+++ b/src/nameko_prometheus/dependencies.py
@@ -88,7 +88,11 @@ class PrometheusMetrics(DependencyProvider):
             if isinstance(entrypoint, HttpRequestHandler):
                 http_method = entrypoint.method
                 url = entrypoint.url
-                status_code = entrypoint.response_from_result(result).status_code
+                if exc_info:
+                    _, exc, _ = exc_info
+                    status_code = entrypoint.response_from_exception(exc).status_code
+                else:
+                    status_code = entrypoint.response_from_result(result).status_code
                 logger.debug(f"Tracing HTTP request: {http_method} {url} {status_code}")
                 self.http_request_total_counter.labels(
                     http_method=http_method, endpoint=url, status_code=status_code


### PR DESCRIPTION
If the HTTP entrypoint raised an exception, nameko-prometheus used
incorrectly `HttpRequestHandlerresponse_from_result()`. Because the
result was None (and only exc_info matters in this case), the entire
worker crashed with `TypeError: Payload must be a string. Got None`.