### PR TITLE
Service state metrics

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.8
 
 [mypy-eventlet.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,11 @@ setup(
         "Issue Tracker": "https://github.com/emplocity/nameko-prometheus/issues",
     },
     python_requires=">=3.6.*",
-    install_requires=["nameko>=2,<3", "prometheus_client>=0.7,<1"],
+    install_requires=[
+        "nameko>=2,<3",
+        "prometheus_client>=0.7,<1",
+        'dataclasses>=0.8,<0.9; python_version<"3.7.0"',
+        'singledispatchmethod>=1.0,<2.0; python_version<"3.8.0"',
+    ],
     setup_requires=["pytest-runner"],
 )

--- a/src/nameko_prometheus/dependencies.py
+++ b/src/nameko_prometheus/dependencies.py
@@ -9,14 +9,14 @@ from weakref import WeakKeyDictionary
 try:
     from functools import singledispatchmethod
 except ImportError:
-    from singledispatchmethod import singledispatchmethod
+    from singledispatchmethod import singledispatchmethod  # type: ignore
 
 from nameko.containers import WorkerContext
 from nameko.events import EventHandler
 from nameko.extensions import DependencyProvider, Entrypoint
 from nameko.rpc import Rpc
 from nameko.web.handlers import HttpRequestHandler
-from prometheus_client import Counter, Histogram, Gauge
+from prometheus_client import Counter, Gauge, Histogram
 from prometheus_client.exposition import choose_encoder
 from prometheus_client.registry import REGISTRY
 from werkzeug.wrappers import Request, Response

--- a/tests/test_nameko_prometheus.py
+++ b/tests/test_nameko_prometheus.py
@@ -64,6 +64,7 @@ def test_expose_default_metrics(config, container_factory, web_session):
     response = web_session.get("/metrics")
     # assert that default metrics are exposed in Prometheus text format
     assert f"TYPE {MyService.name}_rpc_requests_total counter" in response.text
+    assert f"TYPE {MyService.name}_service_max_workers gauge" in response.text
     assert (
         f'{MyService.name}_rpc_requests_total{{method_name="update_counter"}} 2.0'
         in response.text

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
 [testenv]
 basepython =
-    {docs,spell}: {env:TOXPYTHON:python3.6}
+    {docs,spell}: {env:TOXPYTHON:python3.8}
     {bootstrap,clean,check,report}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests


### PR DESCRIPTION
This PR adds several default metrics related to service state: service version, uptime, number of running/max workers. I've refactored the dependency to use singledispatch for readability. 