### PR TITLE
Try to import both function names from prometheus-client.

### DIFF
--- a/src/nameko_prometheus/dependencies.py
+++ b/src/nameko_prometheus/dependencies.py
@@ -17,7 +17,12 @@ from nameko.extensions import DependencyProvider, Entrypoint
 from nameko.rpc import Rpc
 from nameko.web.handlers import HttpRequestHandler
 from prometheus_client import Counter, Gauge, Histogram
-from prometheus_client.exposition import choose_encoder
+
+try:
+    from prometheus_client.exposition import choose_encoder
+except ImportError:
+    from prometheus_client.exposition import choose_formatter as choose_encoder
+
 from prometheus_client.registry import REGISTRY
 from werkzeug.wrappers import Request, Response
 


### PR DESCRIPTION
Even though prometheus-client brought back the old name
(choose_encoder), we can support both 0.14.0 as well as other versions.

Fixes #19.