### PR TITLE
Require prometheus-client 0.15 or newer.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ setup(
         "Changelog": "https://nameko-prometheus.readthedocs.io/en/latest/changelog.html",
         "Issue Tracker": "https://github.com/emplocity/nameko-prometheus/issues",
     },
-    python_requires=">=3.8.*",
+    python_requires=">=3.8",
     install_requires=[
         "nameko>=2,<4",
-        "prometheus_client>=0.7,<1",
+        "prometheus_client>=0.15,<1",
     ],
 )

--- a/src/nameko_prometheus/dependencies.py
+++ b/src/nameko_prometheus/dependencies.py
@@ -17,12 +17,7 @@ from nameko.extensions import DependencyProvider, Entrypoint
 from nameko.rpc import Rpc
 from nameko.web.handlers import HttpRequestHandler
 from prometheus_client import Counter, Gauge, Histogram
-
-try:
-    from prometheus_client.exposition import choose_encoder
-except ImportError:
-    from prometheus_client.exposition import choose_formatter as choose_encoder
-
+from prometheus_client.exposition import choose_encoder
 from prometheus_client.registry import REGISTRY, CollectorRegistry, RestrictedRegistry
 from werkzeug.wrappers import Request, Response
 


### PR DESCRIPTION
choose_encoder was removed in 0.15 and we're targeting only the new API.